### PR TITLE
[pool-16] - LateKillAllWorkers should kill all live workers

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,5 +1,9 @@
 ## History
 
+### v0.7.1
+
+ - LateKillAllWorkers() will kill all alive workers (not only the number of workers that were alive when the function was invoked)
+
 ### v0.7
 
  - Repository name modified to "goworkerpool"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,10 @@
 ## Go :: Pool of workers
 Simple Pool of concurrent workers that allows to dynamically update / pause / resume live workers.
 
+## Prerequisites
+
+Golang version >= 1.9
+
 ## Installation
 ```bash
 go get gopkg.in/enriquebris/goworkerpool.v0

--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,10 @@ pool.WaitUntilNSuccesses(n)
 
 ## History
 
+### v0.7.1
+
+ - LateKillAllWorkers() will kill all alive workers (not only the number of workers that were alive when the function was invoked)
+
 ### v0.7
 
  - Repository name modified to "goworkerpool"


### PR DESCRIPTION
bug fixed: LateKillAllWorkers() will kill all alive workers, not only the number of workers that were alive when the function was executed.